### PR TITLE
fix: Remove count on config map

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,6 @@ resource "kubernetes_deployment" "wandb" {
           }
 
           env {
-            count = var.cloud_monitoring_connection_string != "" ? 1 : 0
             name  = "GORILLA_CUSTOM_METRICS_PROVIDER"
             value = var.cloud_monitoring_connection_string
           }

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ resource "kubernetes_deployment" "wandb" {
           }
 
           env {
+            count = var.cloud_monitoring_connection_string != "" ? 1 : 0
             name  = "GORILLA_CUSTOM_METRICS_PROVIDER"
             value = var.cloud_monitoring_connection_string
           }
@@ -148,7 +149,7 @@ resource "kubernetes_deployment" "wandb" {
         volume {
           name = local.app_name
           config_map {
-            name     = length(kubernetes_config_map.config_map) > 0 ? kubernetes_config_map.config_map[0].metadata[0].name : local.app_name
+            name     = kubernetes_config_map.config_map.metadata[0].name
             optional = true
           }
         }
@@ -181,7 +182,6 @@ resource "kubernetes_service" "service" {
 }
 
 resource "kubernetes_config_map" "config_map" {
-  count = var.redis_ca_cert != "" ? 1 : 0
   metadata {
     name = local.app_name
   }

--- a/variables.tf
+++ b/variables.tf
@@ -119,5 +119,5 @@ variable "redis_ca_cert" {
 variable "cloud_monitoring_connection_string" {
   type        = string
   description = "The cloud provider to publish custom system metrics to for monitoring. Possible values are s3://, gs://, or az://."
-  default     = ""
+  default     = "noop://"
 }


### PR DESCRIPTION
Creating this conditionally was causing a terraform error to be thrown because we create redis conditionally and therefore terraform can't accurately plan if the config map needs to be created or not. I removed the count so we always create the config map now, but I'm wondering if there is a better solution to this?