### PR TITLE
chore: Tell gorilla what its `resource.{requests,limits}.memory` is

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,26 @@ resource "kubernetes_deployment" "wandb" {
           }
 
           env {
+            name  = "GORILLA_MEM_REQUEST"
+            value_from {
+              resource_field_ref {
+                container_name = local.app_name
+                resource       = "requests.memory"
+              }
+            }
+          }
+
+          env {
+            name  = "GORILLA_MEM_LIMIT"
+            value_from {
+              resource_field_ref {
+                container_name = local.app_name
+                resource       = "limits.memory"
+              }
+            }
+          }
+
+          env {
             name  = "LICENSE"
             value = var.license
           }


### PR DESCRIPTION
Provide gorilla its memory request and limit. This way, gorilla can use this information to mark itself unhealthy for k8s to stop sending it requests: https://github.com/wandb/core/pull/9695

Note: this functionality of marking itself unhealthy based on memory usage is turned **off** by default.