### PR TITLE
fix: Use the right version of kube provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,6 +4,7 @@ terraform {
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.16"
+      
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6"
+      version = "~> 2.16"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,6 @@ terraform {
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.16"
-      
     }
   }
 }


### PR DESCRIPTION
Available since: https://registry.terraform.io/providers/hashicorp/kubernetes/2.16.0/docs/resources/deployment