### PR TITLE
fix(dev): Add passthrough for env vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,11 @@ locals {
   weave_app_name     = "weave"
   parquet_app_name   = "parquet"
   redis_ca_cert_name = "server_ca.pem"
-  static_secrets     = {
+  static_secrets = {
     "MYSQL"       = var.database_connection_string
     "OIDC_SECRET" = var.oidc_secret
   }
-  all_secrets        = merge(local.static_secrets, var.other_wandb_secrets)
+  all_secrets = merge(local.static_secrets, var.other_wandb_secrets)
 }
 
 resource "kubernetes_service_account" "default" {
@@ -17,7 +17,7 @@ resource "kubernetes_service_account" "default" {
     labels      = var.service_account_labels
   }
 
-  automount_service_account_token  = true
+  automount_service_account_token = true
 }
 
 resource "kubernetes_priority_class" "priority" {
@@ -25,9 +25,9 @@ resource "kubernetes_priority_class" "priority" {
     name = "wandb-priority"
   }
 
-  value = 1000000000
+  value          = 1000000000
   global_default = false
-  description = "Priority class for wandb pods."
+  description    = "Priority class for wandb pods."
 }
 
 resource "kubernetes_deployment" "wandb" {
@@ -156,27 +156,35 @@ resource "kubernetes_deployment" "wandb" {
           }
 
           env {
-            name = "WEAVE_SERVICE"
+            name  = "WEAVE_SERVICE"
             value = var.weave_enabled ? "${kubernetes_service.weave.0.metadata.0.name}:9994" : ""
           }
 
           env {
-            name = "PARQUET_ENABLED"
+            name  = "PARQUET_ENABLED"
             value = var.weave_enabled ? "true" : "false"
           }
 
           env {
-            name = "PARQUET_HOST"
+            name  = "PARQUET_HOST"
             value = var.parquet_enabled ? "http://${kubernetes_service.parquet.0.metadata.0.name}:8087" : ""
           }
 
           env {
-            name = "WEAVE_ENABLED"
+            name  = "WEAVE_ENABLED"
             value = var.weave_enabled ? "true" : "false"
           }
 
           dynamic "env" {
             for_each = var.other_wandb_env
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.app_wandb_env
             content {
               name  = env.key
               value = env.value

--- a/parquet.tf
+++ b/parquet.tf
@@ -28,7 +28,7 @@ resource "kubernetes_deployment" "parquet" {
         priority_class_name = kubernetes_priority_class.priority.metadata[0].name
 
         container {
-          name = local.parquet_app_name
+          name              = local.parquet_app_name
           image             = "${var.wandb_image}:${var.wandb_version}"
           image_pull_policy = "Always"
 
@@ -39,7 +39,7 @@ resource "kubernetes_deployment" "parquet" {
           }
 
           env {
-            name = "ONLY_SERVICE"
+            name  = "ONLY_SERVICE"
             value = "gorilla-parquet"
           }
 
@@ -134,17 +134,17 @@ resource "kubernetes_deployment" "parquet" {
           }
 
           env {
-            name = "WEAVE_SERVICE"
+            name  = "WEAVE_SERVICE"
             value = var.weave_enabled ? "${kubernetes_service.weave.0.metadata.0.name}:9994" : ""
           }
 
           env {
-            name = "PARQUET_ENABLED"
+            name  = "PARQUET_ENABLED"
             value = var.weave_enabled ? "true" : "false"
           }
 
           env {
-            name = "WEAVE_ENABLED"
+            name  = "WEAVE_ENABLED"
             value = var.weave_enabled ? "true" : "false"
           }
 
@@ -157,13 +157,22 @@ resource "kubernetes_deployment" "parquet" {
             }
           }
 
+          dynamic "env" {
+            for_each = var.parquet_wandb_env
+            content {
+              name  = env.key
+              value = env.value
+
+            }
+          }
+
           env {
-            name = "GORILLA_STATSD_HOST"
+            name  = "GORILLA_STATSD_HOST"
             value = "datadog.datadog"
           }
 
           env {
-            name = "GORILLA_STATSD_PORT"
+            name  = "GORILLA_STATSD_PORT"
             value = "8125"
           }
 
@@ -229,8 +238,8 @@ resource "kubernetes_service" "parquet" {
       app = local.parquet_app_name
     }
     port {
-      name      = "http"
-      port      = 8087
+      name        = "http"
+      port        = 8087
       target_port = 8087
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -120,15 +120,15 @@ variable "weave_resource_limits" {
 }
 
 variable "other_wandb_env" {
-  type    = map(string)
+  type        = map(string)
   description = "Other environment variables to pass to the wandb/local container"
-  default = {}
+  default     = {}
 }
 
 variable "other_wandb_secrets" {
-  type    = map(string)
+  type        = map(string)
   description = "Other secret environment variables to pass to the wandb/local container"
-  default = {}
+  default     = {}
 }
 
 # variable "slack_client_id" {
@@ -202,14 +202,14 @@ variable "cloud_monitoring_connection_string" {
 }
 
 variable "weave_enabled" {
-  type       = bool
-  default    = false
+  type        = bool
+  default     = false
   description = "whether to enable Weave or not"
 }
 
 variable "parquet_enabled" {
-  type       = bool
-  default    = false
+  type        = bool
+  default     = false
   description = "whether to enable Parquet independently or not"
 }
 
@@ -256,9 +256,9 @@ variable "weave_storage_type" {
 }
 
 variable "service_account_name" {
-  type = string
+  type        = string
   description = "The name of the service account to use for the wandb/local deployment."
-  default = "wandb-serviceaccount"
+  default     = "wandb-serviceaccount"
 }
 
 variable "service_account_annotations" {
@@ -279,4 +279,22 @@ variable "deployment_pod_labels" {
 variable "wandb_replicas" {
   type    = number
   default = 1
+}
+
+variable "weave_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+variable "app_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
+}
+
+variable "parquet_wandb_env" {
+  type        = map(string)
+  description = "Extra environment variables for W&B"
+  default     = {}
 }

--- a/weave.tf
+++ b/weave.tf
@@ -28,32 +28,32 @@ resource "kubernetes_deployment" "weave" {
         priority_class_name = kubernetes_priority_class.priority.metadata[0].name
 
         container {
-          name = local.weave_app_name
+          name              = local.weave_app_name
           image             = "${var.wandb_image}:${var.wandb_version}"
           image_pull_policy = "Always"
 
           env {
-            name = "ONLY_SERVICE"
+            name  = "ONLY_SERVICE"
             value = "weave"
           }
 
           env {
-            name = "WANDB_BASE_URL"
-            value = "${var.host}"
+            name  = "WANDB_BASE_URL"
+            value = var.host
           }
 
           env {
-            name = "WEAVE_AUTH_GRAPHQL_URL"
+            name  = "WEAVE_AUTH_GRAPHQL_URL"
             value = "${var.host}/graphql"
           }
 
           env {
-            name = "DD_SERVICE"
+            name  = "DD_SERVICE"
             value = "weave-python"
           }
 
           env {
-            name = "DD_ENV"
+            name  = "DD_ENV"
             value = var.dd_env
           }
 
@@ -70,13 +70,29 @@ resource "kubernetes_deployment" "weave" {
           }
 
           env {
-            name = "WEAVE_ENABLE_DATADOG"
+            name  = "WEAVE_ENABLE_DATADOG"
             value = var.weave_enable_datadog ? "true" : "false"
           }
 
           env {
-            name = "DD_PROFILING_ENABLED"
+            name  = "DD_PROFILING_ENABLED"
             value = var.weave_dd_profiling_enabled ? "true" : "false"
+          }
+
+          dynamic "env" {
+            for_each = var.other_wandb_env
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.weave_wandb_env
+            content {
+              name  = env.key
+              value = env.value
+            }
           }
 
           port {
@@ -105,7 +121,7 @@ resource "kubernetes_deployment" "weave" {
               port = "http"
             }
             failure_threshold = 12
-            period_seconds = 10
+            period_seconds    = 10
           }
 
           resources {
@@ -116,7 +132,7 @@ resource "kubernetes_deployment" "weave" {
           dynamic "volume_mount" {
             for_each = var.weave_storage_size != "" ? ["weave-cache"] : []
             content {
-            name       = volume_mount.value
+              name       = volume_mount.value
               mount_path = "/vol/weave/cache"
             }
           }
@@ -131,8 +147,8 @@ resource "kubernetes_deployment" "weave" {
           }
         }
         security_context {
-          fs_group = 0
-          run_as_user = 999
+          fs_group               = 0
+          run_as_user            = 999
           fs_group_change_policy = "OnRootMismatch"
         }
       }
@@ -186,8 +202,8 @@ resource "kubernetes_service" "weave" {
       app = local.weave_app_name
     }
     port {
-      name      = "http"
-      port      = 9994
+      name        = "http"
+      port        = 9994
       target_port = 9994
     }
   }


### PR DESCRIPTION
Allow for weave, parquet, and gorilla env vars to be passed through to the deployments in addition to the global env vars.